### PR TITLE
Fixed issue with FSM timeout not actually timing out

### DIFF
--- a/src/main/scala/com/suprnation/typelevel/fsm/syntax/FSMStateSyntax.scala
+++ b/src/main/scala/com/suprnation/typelevel/fsm/syntax/FSMStateSyntax.scala
@@ -34,6 +34,9 @@ trait FSMStateSyntax {
     def using(nextStateData: D): F[State[S, D, Request, Response]] =
       sF.map(s => s.using(nextStateData))
 
+    def forMax(duration: Option[(FiniteDuration, Request)]): F[State[S, D, Request, Response]] =
+      sF.map(s => s.forMax(duration))
+
     def withNotification(notifies: Boolean): F[State[S, D, Request, Response]] =
       sF.map(_.withNotification(notifies))
 

--- a/src/test/scala/com/suprnation/fsm/TimeoutFSMSuite.scala
+++ b/src/test/scala/com/suprnation/fsm/TimeoutFSMSuite.scala
@@ -1,156 +1,112 @@
 package com.suprnation.fsm
 
 import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Ref}
+import cats.effect.{Deferred, IO, Ref}
+import cats.implicits.catsSyntaxOptionId
 import com.suprnation.actor.Actor.Actor
 import com.suprnation.actor.ActorSystem
-import com.suprnation.actor.fsm.FSM
 import com.suprnation.actor.fsm.FSM.Event
+import com.suprnation.actor.fsm.{FSM, FSMConfig}
 import com.suprnation.typelevel.actors.syntax.ActorSystemDebugOps
-import com.suprnation.typelevel.fsm.syntax.Timeout
+import com.suprnation.typelevel.fsm.syntax.FSMStateSyntaxOps
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
 sealed trait TimeoutState
-case object NoTimeout extends TimeoutState
-case object DefaultTimeout extends TimeoutState
+case object Awake extends TimeoutState
+case object Asleep extends TimeoutState
 
 sealed trait TimeoutRequest
-case class GotoNoTimeoutState(forceTimeout: Timeout[TimeoutRequest] = None) extends TimeoutRequest
-case class GotoTimeoutState(forceTimeout: Timeout[TimeoutRequest] = None) extends TimeoutRequest
+case class Sleep(timedOut: Boolean) extends TimeoutRequest
+case class WakeUp(stayAwakeFor: Option[FiniteDuration] = None) extends TimeoutRequest
+
 
 object TimeoutActor {
-  def timeoutActor(startWith: TimeoutState): IO[Actor[IO, TimeoutRequest]] =
-    FSM[IO, TimeoutState, Int, TimeoutRequest, Any]
-      .when(NoTimeout) {
-        case (Event(GotoNoTimeoutState(None), _), sM) => sM.stay()
-        case (Event(GotoNoTimeoutState(fd), _), sM)   => sM.forMax(fd)
-        case (Event(GotoTimeoutState(_), data), sM)   => sM.stayAndReply(data)
+
+  def forMaxTimeoutActor(startWith: TimeoutState, timedOutDef: Deferred[IO, Boolean]): IO[Actor[IO, TimeoutRequest]] =
+    FSM[IO, TimeoutState, Deferred[IO, Boolean], TimeoutRequest, Any]
+      .when(Awake) {
+        case (Event(Sleep(timedOut), d), sM) if timedOut =>
+          d.complete(true) *>
+            sM.goto(Asleep).replying(Asleep)
+
+        case (Event(_, _), sM) => sM.stayAndReply(Awake)
       }
-      //      .withConfig(FSMConfig.withConsoleInformation)
-      .startWith(startWith, 0)
+      .when(Asleep) {
+        case (Event(WakeUp(stayAwakeFor), _), sM) =>
+          sM.goto(Awake)
+            .forMax(stayAwakeFor.map((_, Sleep(timedOut = true))))
+            .replying(Awake)
+      }
+      .withConfig(FSMConfig.withConsoleInformation)
+      .startWith(startWith, timedOutDef)
+      .initialize
+
+  def stateTimeoutActor(startWith: TimeoutState, stayAwakeFor: FiniteDuration, timedOutDef: Deferred[IO, Boolean]): IO[Actor[IO, TimeoutRequest]] =
+    FSM[IO, TimeoutState, Deferred[IO, Boolean], TimeoutRequest, Any]
+      .when(Awake, stayAwakeFor, Sleep(timedOut = true)) {
+        case (Event(Sleep(timedOut), d), sM) if timedOut =>
+          d.complete(true) *>
+            sM.goto(Asleep).replying(Asleep)
+
+        case (Event(_, _), sM) => sM.stayAndReply(Awake)
+      }
+      .when(Asleep) {
+        case (Event(WakeUp(_), _), sM) =>
+          sM.goto(Awake).replying(Awake)
+      }
+      .withConfig(FSMConfig.withConsoleInformation)
+      .startWith(startWith, timedOutDef)
       .initialize
 
 }
 
 class TimeoutFSMSuite extends AsyncFlatSpec with Matchers {
-  it should "should not timeout if timeout not set" in {
+
+  it should "timeout the Awake state using the 'forMax' and go back to sleep" in {
     (for {
       actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
       buffer <- Ref[IO].of(Vector.empty[Any])
-      peanoNumber <- actorSystem.replyingActorOf[PeanoNumber, Int](PeanoNumbers.peanoNumbers)
 
-      peanoNumberActor <- actorSystem.actorOf[PeanoNumber](
-        AbsorbReplyActor(peanoNumber, buffer),
-        "peano-number-absorb-actor"
+      timedOut <- Deferred[IO, Boolean]
+      timeoutActor <- actorSystem.actorOf(TimeoutActor.forMaxTimeoutActor(Asleep, timedOut))
+
+      actor <- actorSystem.actorOf[TimeoutRequest](
+        AbsorbReplyActor(timeoutActor, buffer),
+        "actor"
       )
-      _ <- peanoNumberActor ! Zero
-      _ <- peanoNumberActor ! Succ
-      _ <- peanoNumberActor ! Succ
-      _ <- peanoNumberActor ! Succ
+      _ <- actor ! WakeUp(stayAwakeFor = 2.seconds.some)
+
+      _ <- IO.race(IO.sleep(5.seconds), timedOut.get)
       _ <- actorSystem.waitForIdle()
       messages <- buffer.get
     } yield messages).unsafeToFuture().map { messages =>
-      messages.toList should be(List(0, 1, 2, 3))
+      messages.toList should be(List(Awake, Asleep))
     }
   }
 
-  it should "timeout based on default timeout state" in {
+  it should "timeout the Awake state using the 'when' timeout and go back to sleep" in {
     (for {
       actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
       buffer <- Ref[IO].of(Vector.empty[Any])
-      peanoNumber <- actorSystem.replyingActorOf[PeanoNumber, Int](PeanoNumbers.peanoNumbers)
 
-      peanoNumberActor <- actorSystem.actorOf[PeanoNumber](
-        AbsorbReplyActor(peanoNumber, buffer),
-        "peano-number-absorb-actor"
+      timedOut <- Deferred[IO, Boolean]
+      timeoutActor <- actorSystem.actorOf(TimeoutActor.stateTimeoutActor(Asleep, 2.seconds, timedOut))
+
+      actor <- actorSystem.actorOf[TimeoutRequest](
+        AbsorbReplyActor(timeoutActor, buffer),
+        "actor"
       )
-      _ <- peanoNumberActor ! Zero
-      _ <- peanoNumberActor ! Succ
-      _ <- peanoNumberActor ! Succ
-      _ <- peanoNumberActor ! Succ
+      _ <- actor ! WakeUp()
+
+      _ <- IO.race(IO.sleep(5.seconds), timedOut.get)
       _ <- actorSystem.waitForIdle()
       messages <- buffer.get
     } yield messages).unsafeToFuture().map { messages =>
-      messages.toList should be(List(0, 1, 2, 3))
+      messages.toList should be(List(Awake, Asleep))
     }
   }
 
-  it should "should timeout if an override timeout is set (when initial was not set)" in {
-    (for {
-      actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
-      buffer <- Ref[IO].of(Vector.empty[Any])
-      peanoNumber <- actorSystem.replyingActorOf[PeanoNumber, Int](PeanoNumbers.peanoNumbers)
-
-      peanoNumberActor <- actorSystem.actorOf[PeanoNumber](
-        AbsorbReplyActor(peanoNumber, buffer),
-        "peano-number-absorb-actor"
-      )
-      _ <- peanoNumberActor ! Zero
-      _ <- peanoNumberActor ! Succ
-      _ <- peanoNumberActor ! Succ
-      _ <- peanoNumberActor ! Succ
-      _ <- actorSystem.waitForIdle()
-      messages <- buffer.get
-    } yield messages).unsafeToFuture().map { messages =>
-      messages.toList should be(List(0, 1, 2, 3))
-    }
-  }
-
-  it should "should timeout if an override timeout is set (when state has default)" in {
-    (for {
-      actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
-      buffer <- Ref[IO].of(Vector.empty[Any])
-      peanoNumber <- actorSystem.replyingActorOf[PeanoNumber, Int](PeanoNumbers.peanoNumbers)
-
-      peanoNumberActor <- actorSystem.actorOf[PeanoNumber](
-        AbsorbReplyActor(peanoNumber, buffer),
-        "peano-number-absorb-actor"
-      )
-      _ <- peanoNumberActor ! Zero
-      _ <- (peanoNumberActor ! Succ).replicateA(10000)
-      _ <- actorSystem.waitForIdle()
-      messages <- buffer.get
-    } yield messages).unsafeToFuture().map { messages =>
-      messages.toList should be(Range.inclusive(0, 10000).toList)
-    }
-  }
-
-  it should "cancel any timeout from the current state once we move to another state" in {
-    (for {
-      actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
-      buffer <- Ref[IO].of(Vector.empty[Any])
-      peanoNumber <- actorSystem.replyingActorOf[PeanoNumber, Int](PeanoNumbers.peanoNumbers)
-
-      peanoNumberActor <- actorSystem.actorOf[PeanoNumber](
-        AbsorbReplyActor(peanoNumber, buffer),
-        "peano-number-absorb-actor"
-      )
-      _ <- peanoNumberActor ! Zero
-      _ <- (peanoNumberActor ! Succ).replicateA(10000)
-      _ <- actorSystem.waitForIdle()
-      messages <- buffer.get
-    } yield messages).unsafeToFuture().map { messages =>
-      messages.toList should be(Range.inclusive(0, 10000).toList)
-    }
-  }
-
-  it should "cancel any timeouts set once we move to another state" in {
-    (for {
-      actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
-      buffer <- Ref[IO].of(Vector.empty[Any])
-      peanoNumber <- actorSystem.replyingActorOf[PeanoNumber, Int](PeanoNumbers.peanoNumbers)
-
-      peanoNumberActor <- actorSystem.actorOf[PeanoNumber](
-        AbsorbReplyActor(peanoNumber, buffer),
-        "peano-number-absorb-actor"
-      )
-      _ <- peanoNumberActor ! Zero
-      _ <- (peanoNumberActor ! Succ).replicateA(10000)
-      _ <- actorSystem.waitForIdle()
-      messages <- buffer.get
-    } yield messages).unsafeToFuture().map { messages =>
-      messages.toList should be(Range.inclusive(0, 10000).toList)
-    }
-  }
 }


### PR DESCRIPTION
The FSM timeout processing upon a state transition was being based on the currentState. This should rather be based on the nextState. 