### PR TITLE
Issue/8 fsm actor context

### DIFF
--- a/src/main/scala/com/suprnation/actor/ActorContext.scala
+++ b/src/main/scala/com/suprnation/actor/ActorContext.scala
@@ -155,8 +155,6 @@ trait MinimalActorContext[F[+_], -Request, +Response] extends ActorRefProvider[F
 
   def child(name: String): F[Option[NoSendActorRef[F]]]
 
-  def system: ActorSystem[F]
-
   def sender: Option[NoSendActorRef[F]]
 
   /** Force the child Actor under the given name to terminate after it finishes processing its current message. Nothing happens if the ActorRef is a child that is already stopped.
@@ -212,5 +210,7 @@ trait ActorContext[F[+_], Request, Response]
   def become(behaviour: ReplyingReceive[F, Request, Response], discardOld: Boolean = true): F[Unit]
 
   def unbecome: F[Unit]
+
+  def system: ActorSystem[F]
 
 }

--- a/src/main/scala/com/suprnation/actor/FaultHandling.scala
+++ b/src/main/scala/com/suprnation/actor/FaultHandling.scala
@@ -107,7 +107,7 @@ abstract class SupervisionStrategy[F[+_]: Monad] {
   /** This method is called after the child has been remove from the set of children. It does not need to do anything special. Exceptions throw from this method do NOT make the actor fail if this happens during termination.
     */
   def handleChildTerminated(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       child: NoSendActorRef[F],
       children: Iterable[NoSendActorRef[F]]
   ): F[Unit]
@@ -115,7 +115,7 @@ abstract class SupervisionStrategy[F[+_]: Monad] {
   /** This method is called to act on the failure of a child: restart if the flag is true, stop otherwise.
     */
   def processFailure(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       restart: Boolean,
       child: NoSendActorRef[F],
       cause: Option[Throwable],
@@ -129,7 +129,7 @@ abstract class SupervisionStrategy[F[+_]: Monad] {
     *   is a lazy collection (a view)
     */
   def handleFailure(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       child: NoSendActorRef[F],
       cause: Throwable,
       stats: ChildRestartStats[F],
@@ -154,7 +154,7 @@ abstract class SupervisionStrategy[F[+_]: Monad] {
   }
 
   def logFailure(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       child: NoSendActorRef[F],
       cause: Option[Throwable],
       decision: Directive
@@ -190,7 +190,7 @@ abstract class SupervisionStrategy[F[+_]: Monad] {
       }
     } else Monad[F].unit
 
-  private def publish(context: MinimalActorContext[F, Nothing, Any], logEvent: LogEvent): F[Unit] =
+  private def publish(context: ActorContext[F, _, _], logEvent: LogEvent): F[Unit] =
     context.system.eventStream.offer(logEvent)
 
   /** Logging of actor failure is done when this is `true`
@@ -243,13 +243,13 @@ case class AllForOneStrategy[F[+_]: Monad: Parallel](
     )
 
   def handleChildTerminated(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       child: NoSendActorRef[F],
       children: Iterable[NoSendActorRef[F]]
   ): F[Unit] = Monad[F].unit
 
   override def processFailure(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       restart: Boolean,
       child: NoSendActorRef[F],
       cause: Option[Throwable],
@@ -296,13 +296,13 @@ case class OneForOneStrategy[F[+_]: Monad](
     copy(maxNrOfRetries = maxNrOfRetries)(decider)
 
   override def handleChildTerminated(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       child: NoSendActorRef[F],
       children: Iterable[NoSendActorRef[F]]
   ): F[Unit] = Applicative[F].unit
 
   override def processFailure(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       restart: Boolean,
       child: NoSendActorRef[F],
       cause: Option[Throwable],
@@ -323,13 +323,13 @@ case class TerminateActorSystem[F[+_]: Concurrent: Parallel](
 ) extends SupervisionStrategy[F] {
 
   def handleChildTerminated(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       child: NoSendActorRef[F],
       children: Iterable[NoSendActorRef[F]]
   ): F[Unit] = Concurrent[F].unit
 
   override def processFailure(
-      context: MinimalActorContext[F, Nothing, Any],
+      context: ActorContext[F, _, _],
       restart: Boolean,
       child: NoSendActorRef[F],
       cause: Option[Throwable],

--- a/src/main/scala/com/suprnation/actor/fsm/FSM.scala
+++ b/src/main/scala/com/suprnation/actor/fsm/FSM.scala
@@ -24,7 +24,7 @@ import com.suprnation.actor.Actor.{Actor, ReplyingReceive}
 import com.suprnation.actor.ActorRef.{ActorRef, NoSendActorRef}
 import com.suprnation.actor.fsm.FSM.{Event, StopEvent}
 import com.suprnation.actor.fsm.State.StateTimeoutWithSender
-import com.suprnation.actor.{ActorLogging, ReplyingActor, SupervisionStrategy}
+import com.suprnation.actor.{ActorLogging, MinimalActorContext, ReplyingActor, SupervisionStrategy}
 import com.suprnation.typelevel.actors.syntax.ActorRefSyntaxOps
 import com.suprnation.typelevel.fsm.syntax._
 
@@ -240,6 +240,10 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
           // State manager will allow us to move from state to state.
           val stateManager: StateManager[F, S, D, Request, Response] =
             new StateManager[F, S, D, Request, Response] {
+
+              override def minimalContext: MinimalActorContext[F, Request, Response] =
+                context.asInstanceOf[MinimalActorContext[F, Request, Response]]
+
               override def goto(nextStateName: S): F[State[S, D, Request, Response]] =
                 currentStateRef.get.map(currentState =>
                   State(nextStateName, currentState.stateData)

--- a/src/main/scala/com/suprnation/actor/fsm/StateManager.scala
+++ b/src/main/scala/com/suprnation/actor/fsm/StateManager.scala
@@ -16,9 +16,14 @@
 
 package com.suprnation.actor.fsm
 
+import com.suprnation.actor.MinimalActorContext
+
 import scala.concurrent.duration.FiniteDuration
 
 trait StateManager[F[+_], S, D, Request, Response] {
+
+  def minimalContext: MinimalActorContext[F, Request, Response]
+
   def forMax(timeoutData: Option[(FiniteDuration, Request)]): F[State[S, D, Request, Response]]
 
   def goto(nextStateName: S): F[State[S, D, Request, Response]]

--- a/src/test/scala/com/suprnation/fsm/ContextFSMSuite.scala
+++ b/src/test/scala/com/suprnation/fsm/ContextFSMSuite.scala
@@ -1,0 +1,91 @@
+package com.suprnation.fsm
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, IO, Ref}
+import cats.implicits.catsSyntaxApplicativeId
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.fsm.FSM.Event
+import com.suprnation.actor.fsm.{FSM, FSMConfig}
+import com.suprnation.actor.{ActorSystem, ReplyingActor}
+import com.suprnation.typelevel.actors.syntax.ActorSystemDebugOps
+import com.suprnation.typelevel.fsm.syntax.FSMStateSyntaxOps
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+
+sealed trait FsmParentState
+case object FsmIdle extends FsmParentState
+case object FsmRunning extends FsmParentState
+
+sealed trait FsmRequest
+case object FsmRun extends FsmRequest
+case object FsmStop extends FsmRequest
+
+sealed trait FsmChildRequest
+case object FsmChildEcho extends FsmChildRequest
+
+case class FsmChild() extends Actor[IO, FsmChildRequest] {
+
+  override def receive: Receive[IO, FsmChildRequest] = { case FsmChildEcho =>
+    FsmChildEcho.pure[IO]
+  }
+}
+
+object ContextFSMSuite {
+
+  def actor(
+      startWith: FsmParentState,
+      stopped: Deferred[IO, Boolean]
+  ): IO[ReplyingActor[IO, FsmRequest, Any]] =
+    FSM[IO, FsmParentState, Int, FsmRequest, Any]
+      .when(FsmIdle) { case (Event(FsmRun, _), sM) =>
+        for {
+          fsmChildActor <- sM.minimalContext.actorOf(FsmChild())
+          result <- fsmChildActor ? FsmChildEcho
+          state <- sM.goto(FsmRunning).replying(result)
+        } yield state
+      }
+      .when(FsmRunning) {
+        case (Event(FsmRun, _), sM) =>
+          (sM.minimalContext.self ! FsmStop) *> sM.stay()
+        case (Event(FsmStop, _), sM) =>
+          stopped.complete(true) *> sM.stay()
+      }
+      .withConfig(FSMConfig.withConsoleInformation)
+      .startWith(startWith, 0)
+      .initialize
+
+}
+
+class ContextFSMSuite extends AsyncFlatSpec with Matchers {
+
+  it should "create child actor and send a message to self" in {
+    (for {
+      actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
+      buffer <- Ref[IO].of(Vector.empty[Any])
+
+      waitForRainDef <- Deferred[IO, Boolean]
+      weatherActor <- actorSystem.actorOf(
+        ContextFSMSuite.actor(
+          startWith = FsmIdle,
+          waitForRainDef
+        )
+      )
+      actor <- actorSystem.actorOf[FsmRequest](
+        AbsorbReplyActor(weatherActor, buffer),
+        "actor"
+      )
+
+      _ <- actor ! FsmRun
+      _ <- actor ! FsmRun
+
+      _ <- IO.race(IO.delay(fail).delayBy(4.seconds), waitForRainDef.get.map(_ should be(true)))
+      _ <- actorSystem.waitForIdle()
+      messages <- buffer.get
+    } yield messages).unsafeToFuture().map { messages =>
+      messages.toList should be(List(FsmChildEcho))
+    }
+  }
+
+}

--- a/src/test/scala/com/suprnation/fsm/ContextFSMSuite.scala
+++ b/src/test/scala/com/suprnation/fsm/ContextFSMSuite.scala
@@ -80,7 +80,7 @@ class ContextFSMSuite extends AsyncFlatSpec with Matchers {
       _ <- actor ! FsmRun
       _ <- actor ! FsmRun
 
-      _ <- IO.race(IO.delay(fail).delayBy(4.seconds), waitForRainDef.get.map(_ should be(true)))
+      _ <- IO.race(IO.delay(fail()).delayBy(4.seconds), waitForRainDef.get.map(_ should be(true)))
       _ <- actorSystem.waitForIdle()
       messages <- buffer.get
     } yield messages).unsafeToFuture().map { messages =>


### PR DESCRIPTION
### Summary
This PR adds the MinimalActorContext to the FSM StateManager. Allows the creation of child actors and send messages to self in an FSM.

Changes:
1. Exposed the MinimalActorContext in the FSM StateManager. 
2. Removed the ActorSystem from the MinimalActorContext as we want to restrict access to the scheduler in the FSMBuilder. Access to the Actor Scheduler would allow someone to transition states in the scheduleOnce functions.
3. Switched the FaultHandler to use the ActorContext instead of the Minimal one since it requires access to the ActorSystem. Switched the Request and Response types to be wildcards since the FaultHandler should never actually make use of them. Before they were allowed to be [... , Nothing, Any] due to the MinimalActorContext allowing co/contra variance, however, the ActorContext only allows for invariance. 

Usage of the FSM ActorContext:
```
FSM[IO, FsmParentState, Int, FsmRequest, Any]
  .when(FsmIdle) { 
    case (Event(FsmRun, _), sM) =>
      for {
        fsmChildActor <- sM.minimalContext.actorOf(FsmChild())
        result <- fsmChildActor ? FsmChildEcho
        state <- sM.goto(FsmRunning).replying(result)
      } yield state
  }
  .when(FsmRunning) {
    case (Event(FsmRun, _), sM) =>
      (sM.minimalContext.self ! FsmStop) *> sM.stay()
    case (Event(FsmStop, _), sM) =>
      stopped.complete(true) *> sM.stay()
  }
  .withConfig(FSMConfig.withConsoleInformation)
  .startWith(startWith, 0)
  .initialize
```