### PR TITLE
Curried FSM StateFunction 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2109,16 +2109,16 @@ object ExampleFSMApp extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = {
     val fsm: IO[Actor[IO, Request]] = FSM[IO, State, Data, Request, Any]
       .withConfig(FSMConfig.withConsoleInformation[IO, State, Data, Request, Any])
-      .when(Idle) { case (FSM.Event(Start, data), stateManager) =>
+      .when(Idle) (stateManager => { case FSM.Event(Start, data) =>
         for {
           newState <- stateManager.goto(Active)
         } yield newState.using(data.copy(counter = data.counter + 1))
-      }
-      .when(Active) { case (FSM.Event(Stop, data), stateManager) =>
+      })
+      .when(Active) (stateManager => { case FSM.Event(Stop, data) =>
         for {
           newState <- stateManager.goto(Idle)
         } yield newState.using(data.copy(counter = data.counter + 1))
-      }
+      })
       .onTransition {
         case (Idle, Active) => IO.println("Transitioning from Idle to Active")
         case (Active, Idle) => IO.println("Transitioning from Active to Idle")

--- a/src/main/scala/com/suprnation/actor/fsm/FSM.scala
+++ b/src/main/scala/com/suprnation/actor/fsm/FSM.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration.FiniteDuration
 object FSM {
 
   type StateFunction[F[+_], S, D, Request, Response] =
-    PartialFunction[(Any, StateManager[F, S, D, Request, Response]), F[
+    StateManager[F, S, D, Request, Response] => PartialFunction[Any, F[
       State[S, D, Request, Response]
     ]]
 
@@ -74,8 +74,8 @@ object FSMBuilder {
         transition =
           (_: State[S, D, Request, Response], _: State[S, D, Request, Response]) => Sync[F].unit
       ),
-      stateFunctions = Map.empty[S, PartialFunction[
-        (FSM.Event[D, Request], StateManager[F, S, D, Request, Response]),
+      stateFunctions = Map.empty[S, StateManager[F, S, D, Request, Response] => PartialFunction[
+        FSM.Event[D, Request],
         F[State[S, D, Request, Response]]
       ]],
       stateTimeouts = Map.empty[S, Option[(FiniteDuration, Request)]],
@@ -131,8 +131,8 @@ case class FSMConfig[F[+_], S, D, Request, Response](
 // In this version we will separate the description from the execution.
 case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response](
     config: FSMConfig[F, S, D, Request, Response],
-    stateFunctions: Map[S, PartialFunction[
-      (FSM.Event[D, Request], StateManager[F, S, D, Request, Response]),
+    stateFunctions: Map[S, StateManager[F, S, D, Request, Response] => PartialFunction[
+      FSM.Event[D, Request],
       F[State[S, D, Request, Response]]
     ]],
     stateTimeouts: Map[S, Option[(FiniteDuration, Request)]],
@@ -146,7 +146,7 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
 ) { builderSelf =>
 
   type StateFunction[R] =
-    PartialFunction[(FSM.Event[D, R], StateManager[F, S, D, Request, Response]), F[
+    StateManager[F, S, D, Request, Response] => PartialFunction[FSM.Event[D, R], F[
       State[S, D, Request, Response]
     ]]
   type Timeout = Option[(FiniteDuration, Request)]
@@ -164,7 +164,9 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
   ): FSMBuilder[F, S, D, Request, Response] =
     if (stateFunctions contains name) {
       copy(
-        stateFunctions = this.stateFunctions + (name -> stateFunctions(name).orElse(function)),
+        stateFunctions = this.stateFunctions + (name -> (stateManager =>
+          stateFunctions(name)(stateManager).orElse(function(stateManager))
+        )),
         stateTimeouts = this.stateTimeouts + (name -> timeout.orElse(stateTimeouts(name)))
       )
     } else {
@@ -199,28 +201,28 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
     )
 
   def withPreStart(
-    preStart: F[Unit]
+      preStart: F[Unit]
   ): FSMBuilder[F, S, D, Request, Response] =
     copy(
       preStart = preStart
     )
 
   def withPostStop(
-    postStop: F[Unit]
+      postStop: F[Unit]
   ): FSMBuilder[F, S, D, Request, Response] =
     copy(
       postStop = postStop
     )
 
   def onActorError(
-    onError: Function2[Throwable, Option[Any], F[Unit]]
+      onError: Function2[Throwable, Option[Any], F[Unit]]
   ): FSMBuilder[F, S, D, Request, Response] =
     copy(
       onError = onError
     )
 
   def withSupervisorStrategy(
-    supervisorStrategy: SupervisionStrategy[F]
+      supervisorStrategy: SupervisionStrategy[F]
   ): FSMBuilder[F, S, D, Request, Response] =
     copy(
       supervisorStrategy = supervisorStrategy.some
@@ -272,7 +274,7 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
               case te if te.isDefinedAt((prev, next)) => te((prev, next))
             }.sequence_
 
-          private val handleEvent: StateFunction[Any] = { case (Event(value, _), _) =>
+          private val handleEvent: StateFunction[Any] = _ => { case Event(value, _) =>
             for {
               currentState <- currentStateRef.get
               _ <- log(
@@ -281,7 +283,8 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
             } yield currentState
           }
 
-          override def preStart: F[Unit] = builderSelf.preStart >> (currentStateRef.get >>= makeTransition)
+          override def preStart: F[Unit] =
+            builderSelf.preStart >> (currentStateRef.get >>= makeTransition)
 
           override def receive: ReplyingReceive[F, Any, Any] = {
             case TimeoutMarker(gen, sender, msg) =>
@@ -322,15 +325,15 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
                         sender.asInstanceOf[Option[ActorRef[F, Nothing]]]
                       )
                   )) >>
-                    stateFunc
-                      .lift((updatedEvent, stateManager))
+                    stateFunc(stateManager)
+                      .lift(updatedEvent)
                       .getOrElse(
-                        handleEvent((updatedEvent.asInstanceOf[FSM.Event[D, Any]], stateManager))
+                        handleEvent(stateManager)(updatedEvent.asInstanceOf[FSM.Event[D, Any]])
                       )
                 case _ =>
-                  stateFunc
-                    .lift((event.asInstanceOf[Event[D, Request]], stateManager))
-                    .getOrElse(handleEvent((event, stateManager)))
+                  stateFunc(stateManager)
+                    .lift(event.asInstanceOf[Event[D, Request]])
+                    .getOrElse(handleEvent(stateManager)(event))
               }
 
               _ <- applyState(state)
@@ -398,7 +401,9 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
             onTerminationCallback.fold(Sync[F].unit)(x => x(reason))
 
           override def postStop: F[Unit] =
-            (stateManager.stay().withStopReason(Shutdown) >>= terminate) >> builderSelf.postStop >> super.postStop
+            (stateManager
+              .stay()
+              .withStopReason(Shutdown) >>= terminate) >> builderSelf.postStop >> super.postStop
 
           private def terminate(nextState: State[S, D, Request, Response]): F[Unit] =
             for {
@@ -416,9 +421,11 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
               }(_ => Sync[F].unit)
             } yield ()
 
-          override def supervisorStrategy: SupervisionStrategy[F] = builderSelf.supervisorStrategy.getOrElse(super.supervisorStrategy)
+          override def supervisorStrategy: SupervisionStrategy[F] =
+            builderSelf.supervisorStrategy.getOrElse(super.supervisorStrategy)
 
-          override def onError(reason: Throwable, message: Option[Any]): F[Unit] = builderSelf.onError(reason, message)
+          override def onError(reason: Throwable, message: Option[Any]): F[Unit] =
+            builderSelf.onError(reason, message)
 
         }).asInstanceOf[ReplyingActor[F, Request, Response]]
       }

--- a/src/main/scala/com/suprnation/typelevel/fsm/syntax/FSMStateSyntax.scala
+++ b/src/main/scala/com/suprnation/typelevel/fsm/syntax/FSMStateSyntax.scala
@@ -51,11 +51,9 @@ trait FSMStateSyntax {
       stateName: S,
       stateTimeout: Timeout[Request] = Option.empty[(FiniteDuration, Request)]
   )(
-      stateFunction: PartialFunction[
-        (FSM.Event[D, Request], StateManager[F, S, D, Request, Response]),
-        F[
-          State[S, D, Request, Response]
-        ]
+      stateFunction: StateManager[F, S, D, Request, Response] => PartialFunction[
+        FSM.Event[D, Request],
+        F[State[S, D, Request, Response]]
       ]
   ): FSMBuilder[F, S, D, Request, Response] =
     FSMBuilder[F, S, D, Request, Response]().when(stateName, stateTimeout)(stateFunction)
@@ -65,11 +63,9 @@ trait FSMStateSyntax {
       stateTimeout: FiniteDuration,
       onTimeout: Request
   )(
-      stateFunction: PartialFunction[
-        (FSM.Event[D, Request], StateManager[F, S, D, Request, Response]),
-        F[
-          State[S, D, Request, Response]
-        ]
+      stateFunction: StateManager[F, S, D, Request, Response] => PartialFunction[
+        FSM.Event[D, Request],
+        F[State[S, D, Request, Response]]
       ]
   ): FSMBuilder[F, S, D, Request, Response] =
     FSMBuilder[F, S, D, Request, Response]().when(stateName, Some(stateTimeout -> onTimeout))(

--- a/src/test/scala/com/suprnation/fsm/DataFSMSuite.scala
+++ b/src/test/scala/com/suprnation/fsm/DataFSMSuite.scala
@@ -20,16 +20,16 @@ case object CurrentState extends PeanoNumber
 
 object PeanoNumbers {
   val peanoNumbers: IO[ReplyingActor[IO, PeanoNumber, Int]] =
-    when[IO, PeanoState, Int, PeanoNumber, Int](Forever) {
-      case (Event(Zero, data), sM: StateManager[IO, PeanoState, Int, PeanoNumber, Int]) =>
+    when[IO, PeanoState, Int, PeanoNumber, Int](Forever)(sM => {
+      case Event(Zero, data) =>
         sM.stayAndReply(data)
 
-      case (Event(Succ, data), sM: StateManager[IO, PeanoState, Int, PeanoNumber, Int]) =>
+      case Event(Succ, data) =>
         sM.stay().using(data + 1).replying(data + 1)
 
-      case (Event(CurrentState, data), sM: StateManager[IO, PeanoState, Int, PeanoNumber, Int]) =>
+      case Event(CurrentState, data) =>
         sM.stayAndReply(data)
-    }
+    })
       //      .withConfig(FSMConfig.withConsoleInformation)
       .startWith(Forever, 0)
       .initialize

--- a/src/test/scala/com/suprnation/fsm/SytlisticFSMSuite.scala
+++ b/src/test/scala/com/suprnation/fsm/SytlisticFSMSuite.scala
@@ -26,39 +26,39 @@ case object Push extends Input
 object Turnstile {
   val turnstileReplyingActorUsingFsmBuilder: IO[Actor[IO, Input]] =
     FSMBuilder[IO, State, Unit, Input, Any]()
-      .when(Locked) { case (Event(Coin, _), sM) =>
+      .when(Locked)(sM => { case Event(Coin, _) =>
         sM.goto(Unlocked).replying(Unlocked)
-      }
-      .when(Unlocked) { case (Event(Push, _), sM) =>
+      })
+      .when(Unlocked)(sM => { case Event(Push, _) =>
         sM.goto(Locked)
           .using(())
           .replying(Locked)
-      }
+      })
       .withConfig(FSMConfig.withConsoleInformation)
       .startWith(Locked, ())
       .initialize
 
   val turnstileReplyingActorUsingWhenSyntaxDirectly: IO[Actor[IO, Input]] =
-    when[IO, State, Unit, Input, Any](Locked) { case (Event(Coin, _), sM) =>
+    when[IO, State, Unit, Input, Any](Locked)(sM => { case Event(Coin, _) =>
       sM.goto(Unlocked).replying(Unlocked)
-    }
-      .when(Unlocked) { case (Event(Push, _), sM) =>
+    })
+      .when(Unlocked)(sM => { case Event(Push, _) =>
         sM.goto(Locked).using(()).replying(Locked)
-      }
+      })
       .withConfig(FSMConfig.withConsoleInformation)
       .startWith(Locked, ())
       .initialize
 
   val turnstileReplyingActorUsingSemigroupConstruction: IO[Actor[IO, Input]] =
     (
-      when[IO, State, Unit, Input, Any](Locked) { case (Event(Coin, _), sM) =>
+      when[IO, State, Unit, Input, Any](Locked)(sM => { case Event(Coin, _) =>
         sM.goto(Unlocked).replying(Unlocked)
-      } |+|
-        when[IO, State, Unit, Input, Any](Unlocked) { case (Event(Push, _), sM) =>
+      }) |+|
+        when[IO, State, Unit, Input, Any](Unlocked)(sM => { case Event(Push, _) =>
           sM.goto(Locked)
             .using(())
             .replying(Locked)
-        }
+        })
     )
       .withConfig(FSMConfig.withConsoleInformation)
       .startWith(Locked, ())


### PR DESCRIPTION
This PR changes the type signature of state functions in FSMs to curry the state manager. This makes the syntax a bit cleaner, especially for multiple cases of events, and slighly closer to Akka (which doesn't need a state manager argument). 

Made up example:
```scala
object Before {

    // Partial function gives the impression the state manager is also changing and something to match against!

    type StateFunction =
      PartialFunction[(FSM.Event[Any, Request], StateManager[IO, SomeState, Any, Request, Any]), IO[
        State[SomeState, Any, Request, Any]
      ]]

    def someStateFunction: StateFunction = {
      case (FSM.Event(Start, _), stateManager) =>
        stateManager.goto(Active)
      case (FSM.Event(Stop, _), stateManager) =>    // we have to repeat the stateManager in each case! 
        stateManager.stay()
    }
  }

  object After {
    type StateFunction = StateManager[IO, SomeState, Any, Request, Any] =>
      PartialFunction[FSM.Event[Any, Request], IO[
        State[SomeState, Any, Request, Any]
      ]]

    def someStateFunction: StateFunction = stateManager => {
        case FSM.Event(Start, _) =>
          stateManager.goto(Active)
        case FSM.Event(Stop, _) =>
          stateManager.stay()
      }
  }
  ```