### PR TITLE
fix: FSM - Termination - Added stateData and referenced correct state

### DIFF
--- a/src/main/scala/com/suprnation/typelevel/fsm/instances/FSMBuilderInstances.scala
+++ b/src/main/scala/com/suprnation/typelevel/fsm/instances/FSMBuilderInstances.scala
@@ -39,12 +39,13 @@ trait FSMBuilderInstances {
           x.terminateEvent(msg) >> y.terminateEvent(msg)
         }
 
-        val terminationCallback: Option[Reason => F[Unit]] =
+        val terminationCallback: Option[(Reason, D) => F[Unit]] =
           (x.onTerminationCallback, y.onTerminationCallback) match {
-            case (None, None)       => None
-            case (l, None)          => l
-            case (None, r)          => r
-            case (Some(l), Some(r)) => Some((reason: Reason) => l(reason) >> r(reason))
+            case (None, None) => None
+            case (l, None)    => l
+            case (None, r)    => r
+            case (Some(l), Some(r)) =>
+              Some((reason: Reason, stateData: D) => l(reason, stateData) >> r(reason, stateData))
           }
 
         val onError: Function2[Throwable, Option[Any], F[Unit]] =

--- a/src/test/scala/com/suprnation/fsm/TerminationFSMSuite.scala
+++ b/src/test/scala/com/suprnation/fsm/TerminationFSMSuite.scala
@@ -1,0 +1,65 @@
+package com.suprnation.fsm
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, IO}
+import com.suprnation.actor.fsm.FSM.Event
+import com.suprnation.actor.fsm.{FSM, FSMConfig, Normal}
+import com.suprnation.actor.{ActorSystem, ReplyingActor}
+import com.suprnation.fsm.TerminationFSMSuite._
+import com.suprnation.typelevel.actors.syntax.ActorSystemDebugOps
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+
+object TerminationFSMSuite {
+
+  private[TerminationFSMSuite] sealed trait FsmState
+  private[TerminationFSMSuite] case object FsmIdle extends FsmState
+
+  private[TerminationFSMSuite] sealed trait FsmRequest
+  private[TerminationFSMSuite] case object FsmStop extends FsmRequest
+
+  def actor(
+      startWith: FsmState,
+      stopped: Deferred[IO, Int]
+  ): IO[ReplyingActor[IO, FsmRequest, Any]] =
+    FSM[IO, FsmState, Int, FsmRequest, Any]
+      .when(FsmIdle)(sM => { case Event(FsmStop, _) =>
+        sM.stop(Normal, 0)
+      })
+      .withConfig(FSMConfig.withConsoleInformation)
+      .onTermination {
+        case (Normal, stateData) =>
+          stopped.complete(stateData).void
+        case _ => IO.unit
+      }
+      .startWith(startWith, 1)
+      .initialize
+
+}
+
+class TerminationFSMSuite extends AsyncFlatSpec with Matchers {
+
+  it should "create child actor and send a message to self" in {
+    (for {
+      actorSystem <- ActorSystem[IO]("FSM Actor", (_: Any) => IO.unit).allocated.map(_._1)
+
+      stoppedDef <- Deferred[IO, Int]
+      actor <- actorSystem.actorOf(
+        TerminationFSMSuite.actor(
+          startWith = FsmIdle,
+          stoppedDef
+        )
+      )
+
+      _ <- actor ! FsmStop
+
+      fsmExitCode <- IO.race(IO.pure(-1).delayBy(4.seconds), stoppedDef.get)
+      _ <- actorSystem.waitForIdle()
+    } yield fsmExitCode).unsafeToFuture().map { fsmExitCode =>
+      fsmExitCode should be(Right(0))
+    }
+  }
+
+}


### PR DESCRIPTION
### Description

1. Added the StateData to the onTermination method in the FSMBuilder.
2. Fixed issue with the FSM termination method using the previous state data instead of the next one.

Example FSM with updated onTermination method:
```
FSM[IO, FsmState, Int, FsmRequest, Any]
  .when(FsmIdle)(sM => { case Event(FsmStop, _) =>
    sM.stop(Normal, 0)
  })
  .withConfig(FSMConfig.withConsoleInformation)
  .onTermination {
    case (Normal, stateData) => ...
    case _ => ...
  }
  .startWith(startWith, 1)
  .initialize
```
