### PR TITLE
feat: Adds current state name and data getters to FSM StateManager

### DIFF
--- a/src/main/scala/com/suprnation/actor/fsm/FSM.scala
+++ b/src/main/scala/com/suprnation/actor/fsm/FSM.scala
@@ -246,6 +246,10 @@ case class FSMBuilder[F[+_]: Parallel: Async: Temporal, S, D, Request, Response]
               override def minimalContext: MinimalActorContext[F, Request, Response] =
                 context.asInstanceOf[MinimalActorContext[F, Request, Response]]
 
+              override def stateName: F[S] = currentStateRef.get.map(_.stateName)
+
+              override def stateData: F[D] = currentStateRef.get.map(_.stateData)
+
               override def goto(nextStateName: S): F[State[S, D, Request, Response]] =
                 currentStateRef.get.map(currentState =>
                   State(nextStateName, currentState.stateData)

--- a/src/main/scala/com/suprnation/actor/fsm/StateManager.scala
+++ b/src/main/scala/com/suprnation/actor/fsm/StateManager.scala
@@ -24,6 +24,10 @@ trait StateManager[F[+_], S, D, Request, Response] {
 
   def minimalContext: MinimalActorContext[F, Request, Response]
 
+  def stateName: F[S]
+
+  def stateData: F[D]
+
   def forMax(timeoutData: Option[(FiniteDuration, Request)]): F[State[S, D, Request, Response]]
 
   def goto(nextStateName: S): F[State[S, D, Request, Response]]


### PR DESCRIPTION
This PR adds references to the current state name and data in the FSM `StateManager`. This allows the user to get that information for their own use, including for debugging purposes, without triggering any transitions.

This is in line with the [original Akka FSM implementation that has these available](https://github.com/akka/akka/blob/641b553777a58f60c2409fa3f86b5a8cff69423a/akka-actor/src/main/scala/akka/actor/FSM.scala#L713-L726).