### PR TITLE
fix: Propagate error to sender when asking

### DIFF
--- a/src/main/scala/com/suprnation/actor/Envelope.scala
+++ b/src/main/scala/com/suprnation/actor/Envelope.scala
@@ -39,7 +39,7 @@ case class Envelope[F[+_], A](
 )
 case class EnvelopeWithDeferred[F[+_], A](
     envelope: Envelope[F, A],
-    deferred: Option[Deferred[F, Any]]
+    deferred: Option[Deferred[F, Either[Throwable, Any]]]
 )
 
 case class SystemMessageEnvelope[F[+_]](

--- a/src/main/scala/com/suprnation/actor/ReplyingActorRef.scala
+++ b/src/main/scala/com/suprnation/actor/ReplyingActorRef.scala
@@ -232,9 +232,9 @@ case class InternalActorRef[F[+_]: Async: Console, Request, Response](
     assertCellActiveAndDo[Any](actorCell =>
       for {
         // Here we need to add the logic not to push to the queue anymore if it shutdown...
-        deferred <- Deferred[F, Any]
+        deferred <- Deferred[F, Either[Throwable, Any]]
         _ <- actorCell.sendMessage(Envelope(fa, sender, receiver), Option(deferred))
-        result <- deferred.get
+        result <- deferred.get.rethrow
       } yield result
     )
 

--- a/src/main/scala/com/suprnation/actor/dungeon/Dispatch.scala
+++ b/src/main/scala/com/suprnation/actor/dungeon/Dispatch.scala
@@ -109,7 +109,7 @@ trait Dispatch[F[+_], Request, Response] {
 
   def ?(fa: Request): F[Response] =
     for {
-      deferred <- Deferred[F, Any]
+      deferred <- Deferred[F, Either[Throwable, Any]]
       _ <- sendMessage(
         Envelope(fa, self),
         Option(deferred)
@@ -119,7 +119,7 @@ trait Dispatch[F[+_], Request, Response] {
 
   override def sendMessage(
       msg: Envelope[F, Any],
-      deferred: Option[Deferred[F, Any]]
+      deferred: Option[Deferred[F, Either[Throwable, Any]]]
   ): F[Unit] =
     // Here we need to see if the system is terminated... if it is we send all messages to the dead letter
     dispatchContext.mailbox

--- a/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
+++ b/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
@@ -223,20 +223,10 @@ object ActorCell {
                 }
                 .uncancelable
                 .recoverWith { (error: Throwable) =>
-                  deferred match {
-                    case None =>
-                      isIdleTrue
-                    case Some(d) =>
-                      d.complete(Left(error)).map(_ => _isIdle = true)
-                  }
-                } >>= (result =>
-              deferred match {
-                case None =>
-                  isIdleTrue
-                case Some(d) =>
-                  d.complete(Right(result)).map(_ => _isIdle = true)
-              }
-            )
+                  deferred.fold(isIdleTrue)(d => d.complete(Left(error)).map(_ => _isIdle = true))
+                } >>= { result =>
+              deferred.fold(isIdleTrue)(d => d.complete(Right(result)).map(_ => _isIdle = true))
+            }
           }
 
       def publish(e: Class[?] => LogEvent): F[Unit] =

--- a/src/main/scala/com/suprnation/actor/engine/Cell.scala
+++ b/src/main/scala/com/suprnation/actor/engine/Cell.scala
@@ -69,7 +69,10 @@ trait Cell[F[+_], Request, Response] {
     *
     * Note internally messages are not typed, the typing comes on the layer on top of the actors.
     */
-  def sendMessage(msg: Envelope[F, Any], deferred: Option[Deferred[F, Either[Throwable, Any]]] = None): F[Unit]
+  def sendMessage(
+      msg: Envelope[F, Any],
+      deferred: Option[Deferred[F, Either[Throwable, Any]]] = None
+  ): F[Unit]
 
   /** Enqueue a message to be sent to the actor system queue; may or may not actually schedule the actor to run, depending on which type of cell it is.
     */

--- a/src/main/scala/com/suprnation/actor/engine/Cell.scala
+++ b/src/main/scala/com/suprnation/actor/engine/Cell.scala
@@ -69,7 +69,7 @@ trait Cell[F[+_], Request, Response] {
     *
     * Note internally messages are not typed, the typing comes on the layer on top of the actors.
     */
-  def sendMessage(msg: Envelope[F, Any], deferred: Option[Deferred[F, Any]] = None): F[Unit]
+  def sendMessage(msg: Envelope[F, Any], deferred: Option[Deferred[F, Either[Throwable, Any]]] = None): F[Unit]
 
   /** Enqueue a message to be sent to the actor system queue; may or may not actually schedule the actor to run, depending on which type of cell it is.
     */

--- a/src/test/scala/com/suprnation/actor/ask/AskSpec.scala
+++ b/src/test/scala/com/suprnation/actor/ask/AskSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 SuprNation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.suprnation.actor.ask
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.effect.implicits._
+import cats.implicits._
+import com.suprnation.actor.Actor.ReplyingReceive
+import com.suprnation.actor.{ActorSystem, ReplyingActor}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Assertions
+import org.scalatest.exceptions.TestFailedException
+
+object AskSpec {
+  sealed trait Input
+  case object Hi extends Input
+  case object Error extends Input
+
+  def askReceiver(response: Int, error: String): ReplyingActor[IO, Input, Int] = new ReplyingActor[IO, Input, Int] {
+    override def receive: ReplyingReceive[IO, Any, Int] = {
+      case Hi => response.pure[IO]
+      case Error => IO.raiseError(new Exception(error))
+    }
+  }
+}
+
+class AskSpec extends AsyncFlatSpec with Matchers with Assertions {
+
+  import AskSpec._
+
+  it should "return the correct response" in {
+    ActorSystem[IO]("AskSpec").use { system =>
+      for {
+        actor <- system.replyingActorOf(askReceiver(4567, "oops"))
+
+        response <- actor ? Hi
+      } yield (response shouldBe 4567)
+    }.unsafeToFuture()
+
+  }
+
+  it should "catch errors" in {
+    ActorSystem[IO]("AskSpec").use { system =>
+      for {
+        actor <- system.replyingActorOf(askReceiver(4567, "oops"))
+
+        response <- actor ? Error
+      } yield fail(s"Expected exception but got response instead: $response")
+    }.recover {
+      case oops: Throwable if oops.getMessage.equals("oops") => succeed
+      case ex: Throwable if !ex.isInstanceOf[TestFailedException]=> 
+        ex.printStackTrace()
+        fail("Unexpected exception", ex)
+    }.unsafeToFuture()
+
+  }
+
+
+ 
+}


### PR DESCRIPTION
fixes #25

Lets `ActorCell$.invoke` propagate exceptions to `processMailbox` and then through the `Deferred` back to the sender.

The `Deferred` has to be an `Either` as a channel for the exception.

Added a unit test for this as well.

Note that an exception in the receiver will now make both the receiver and the sender fail (as opposed to only the receiver).