### PR TITLE
fix: Improved the isTerminated semantics to be based on the ActorCell instead of the Mailbox

### DIFF
--- a/src/main/scala/com/suprnation/actor/dispatch/mailbox/Mailboxes.scala
+++ b/src/main/scala/com/suprnation/actor/dispatch/mailbox/Mailboxes.scala
@@ -79,7 +79,7 @@ object Mailboxes {
 
       @inline override val isSuspended: F[Boolean] = false.pure[F]
 
-      @inline override val isClosed: F[Boolean] = true.pure[F]
+      @inline override val isClosed: F[Boolean] = false.pure[F]
 
       @inline override val resume: F[Unit] =
         Concurrent[F].raiseError(

--- a/src/main/scala/com/suprnation/actor/dungeon/Dispatch.scala
+++ b/src/main/scala/com/suprnation/actor/dungeon/Dispatch.scala
@@ -83,8 +83,6 @@ trait Dispatch[F[+_], Request, Response] {
 
   final def numberOfMessages: F[Int] = dispatchContext.mailbox.numberOfMessages
 
-  final def isTerminated: F[Boolean] = dispatchContext.mailbox.isClosed
-
   final def suspend(causeByFailure: Option[Throwable]): F[Unit] =
     this
       .sendSystemMessage(Envelope.system(SystemMessage.Suspend(causeByFailure)))

--- a/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
+++ b/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
@@ -93,6 +93,7 @@ object ActorCell {
 
       override def currentMessage: Option[Envelope[F, Any]] = _currentMessage
 
+      var _isTerminated: Boolean = false
       var _isIdle: Boolean = true
       val isIdleTrue: F[Unit] = Temporal[F].delay { _isIdle = true }
 
@@ -283,6 +284,7 @@ object ActorCell {
           Temporal[F].delay {
             creationContext.actorContextOp = None
             _isIdle = true
+            _isTerminated = true
           }
 
       override def finishTerminate: F[Unit] =
@@ -330,6 +332,8 @@ object ActorCell {
               clearActorFields(false) >>
               clearFieldsForTermination
           )
+
+      override final def isTerminated: F[Boolean] = _isTerminated.pure[F]
 
       override def setReceiveTimeout(timeout: FiniteDuration, onTimeout: => Request): F[Unit] =
         receiveTimeout.setReceiveTimeout(timeout, onTimeout)

--- a/src/main/scala/com/suprnation/typelevel/actors/syntax/ActorSystemDebugSyntax.scala
+++ b/src/main/scala/com/suprnation/typelevel/actors/syntax/ActorSystemDebugSyntax.scala
@@ -32,8 +32,8 @@ trait ActorSystemDebugSyntax {
       actorSystem: ActorSystem[F]
   ) {
     def waitForIdle(
-        checkSchedulerIdle: Boolean = true,
-        maxTimeout: Duration = 30 second
+        maxTimeout: Duration = 30 second,
+        checkSchedulerIdle: Boolean = true
     ): F[List[NoSendActorRef[F]]] =
       Concurrent[F]
         .race(
@@ -51,7 +51,7 @@ trait ActorSystemDebugSyntax {
               .pure[F]
               .ifM(
                 Temporal[F].unit,
-                waitForIdle(checkSchedulerIdle, maxTimeout).void
+                waitForIdle(maxTimeout, checkSchedulerIdle).void
               )
             _ <- deadLetters.waitForIdle
             _ <- actorSystem.isTerminated.ifM(

--- a/src/test/scala/com/suprnation/actor/test/TestKitSpec.scala
+++ b/src/test/scala/com/suprnation/actor/test/TestKitSpec.scala
@@ -138,6 +138,23 @@ class TestKitSpec extends AsyncFlatSpec with Matchers with TestKit {
     }
   }
 
+  "receiveWhile" should "stop without error when timeout is exceeded" in {
+    testActorSystem { case (_, actorRef) =>
+      for {
+        _ <- actorRef ! "Bye"
+        _ <- actorRef ! "Bye"
+        _ <- actorRef ! "Bye"
+
+        receivedMessage <- receiveWhile(actorRef, 1 second) { case s: String =>
+          s
+        }
+      } yield {
+        receivedMessage should have size 3
+        receivedMessage should contain theSameElementsAs Vector("Bye", "Bye", "Bye")
+      }
+    }
+  }
+
   "within" should "raise exception when code block takes longer than max time" in {
     testActorSystem(Actor.withReceive[IO, Any] { case s =>
       IO.sleep(400 millis).as(s)


### PR DESCRIPTION
### Description
In [this previous PR](https://github.com/PetrosPapapa/cats-actors/pull/11), I modified the `DeadLetterMailbox.isClosed` method to always return `true` instead of `false` to align with how `Dispatcher.isTerminated` checked the mailbox status to determine an actor's liveliness. However, semantically, this was incorrect because a dead-letter mailbox should never be considered closed.

This PR reverts that change and relocates the `isTerminated` method from `Dispatcher` to `ActorCell`. The new logic for `isTerminated` now correctly checks if the actor has been successfully terminated.

Additionally, I have included tests for the `TestKitSpec.within` method.