### PR TITLE
fix: expand uncancelable scope to prevent ask pattern deadlock during system termination

### DIFF
--- a/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
+++ b/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
@@ -222,12 +222,13 @@ object ActorCell {
                   }
                   result
                 }
-                .uncancelable
                 .recoverWith { (error: Throwable) =>
                   deferred.fold(isIdleTrue)(d => d.complete(Left(error)).map(_ => _isIdle = true))
-                } >>= { result =>
-              deferred.fold(isIdleTrue)(d => d.complete(Right(result)).map(_ => _isIdle = true))
-            }
+                }
+                .flatMap { result =>
+                  deferred.fold(isIdleTrue)(d => d.complete(Right(result)).map(_ => _isIdle = true))
+                }
+                .uncancelable
           }
 
       def publish(e: Class[?] => LogEvent): F[Unit] =


### PR DESCRIPTION
This PR proposes a mitigation to the issue reported in [#32](https://github.com/suprnation/cats-actors/pull/32).

Details:
Currently if the actor system is terminated, pending `ask` messages will never be completed and will keep the process indefinitely blocked. The reason for this seems to be within `processMailbox`, due to the fact that `invoke` is made _uncancelable_, but not including the consecutive deferred completion. This can lead to the completion being cancelled while the sender remains waiting in an uncancelable state.

The proposed mitigation expands the _uncancelable_ scope to include the deferred completion.

Note:
The added test would fail if the change was reverted. A timeout of 2 seconds was added to make sure the tests will not hang indefinitely in this case.

Further possibility:
The issue may still arise in case there is a pending deferred in the mailbox for a message whose processing never even began. For such case I wonder if it would make sense to have a step during termination which clears the mailbox by completing all remaining deferred with an appropriate error indicating that a termination prevented completion.