### PR TITLE
Bugfix escalateDefault, README, and ifM

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,8 +545,8 @@ case class EchoActor() extends Actor[IO, String] {
 case class ParentActor() extends Actor[IO, String] {
   override def receive: Receive[IO, String] = { case "createChildren" =>
     for {
-      child1 <- context.system.actorOf(EchoActor(), "childActor1")
-      child2 <- context.system.actorOf(EchoActor(), "childActor2")
+      child1 <- context.actorOf(EchoActor(), "childActor1")
+      child2 <- context.actorOf(EchoActor(), "childActor2")
       _ <- List(child1, child2).parTraverse_(_ ! "Hello from ParentActor")
     } yield ()
   }
@@ -585,7 +585,7 @@ case class EchoActor() extends Actor[IO, String] {
 case class GrandParentActor() extends Actor[IO, String] {
   override def receive: Receive[IO, String] = { case "createParent" =>
     for {
-      parent <- context.system.actorOf(ParentActor(), "parentActor")
+      parent <- context.actorOf(ParentActor(), "parentActor")
       _ <- parent ! "createChild"
     } yield ()
   }

--- a/src/main/scala/com/suprnation/actor/FaultHandling.scala
+++ b/src/main/scala/com/suprnation/actor/FaultHandling.scala
@@ -44,7 +44,7 @@ object SupervisorStrategy {
     case _: DeathPactException[?]           => Stop
     case _: Exception                       => Restart
   }
-  final val escalateDefault: Decider = (_: Any) => Escalate
+  final val escalateDefault: Decider = (_: Throwable) => Escalate
 
   /** When supervisorStrategy is not specified for an actor this is used by default. OneForOneStrategy with decider defined in [[#defaultDecider]]
     */

--- a/src/main/scala/com/suprnation/actor/dispatch/mailbox/Mailboxes.scala
+++ b/src/main/scala/com/suprnation/actor/dispatch/mailbox/Mailboxes.scala
@@ -279,12 +279,10 @@ object Mailboxes {
                 }
               }
             _ <- Sync[F]
-              .delay(systemQueue.isEmpty && userQueue.isEmpty)
-              .ifM(
+              .whenA(systemQueue.isEmpty && userQueue.isEmpty)(
                 // Note that here we run lock free, this is because we are guaranteed to receive the ping in this scenario
                 // so even though we might have missed this update we will get it in the next ping.
-                Deferred[F, Unit].map(d => deferred = d) >> deferred.get,
-                Sync[F].unit
+                Deferred[F, Unit].map(d => deferred = d) >> deferred.get
               )
           } yield ()
 

--- a/src/main/scala/com/suprnation/actor/dungeon/Creation.scala
+++ b/src/main/scala/com/suprnation/actor/dungeon/Creation.scala
@@ -72,12 +72,9 @@ trait Creation[F[+_], Request, Response] {
           (newActor >>= ((created: ReplyingActor[F, Request, Response]) =>
             created.aroundPreStart()
           )) >>
-            system.settings.DebugLifecycle
-              .pure[F]
-              .ifM(
-                publish(clazz => Debug(self.path.toString, clazz, "started (" + clazz + ")")),
-                asyncF.unit
-              )
+            asyncF.whenA(system.settings.DebugLifecycle)(
+              publish(clazz => Debug(self.path.toString, clazz, "started (" + clazz + ")"))
+            )
         ).recoverWith { case NonFatal(e) =>
           failActor >> (e match {
             case i: InstantiationException =>

--- a/src/main/scala/com/suprnation/actor/dungeon/DeathWatch.scala
+++ b/src/main/scala/com/suprnation/actor/dungeon/DeathWatch.scala
@@ -143,12 +143,9 @@ trait DeathWatch[F[+_], Request, Response] {
           deathWatchContext.watchedByRef.get >>= (watchedBy =>
             if (!watchedBy.contains(watcher)) {
               deathWatchContext.watchedByRef.update(watchedBy => watchedBy + watcher) >>
-                system.settings.DebugLifecycle
-                  .pure[F]
-                  .ifM(
-                    publish(Debug(self.self.path.toString, _, s"now watched by $watcher")),
-                    asyncF.unit
-                  )
+                asyncF.whenA(system.settings.DebugLifecycle)(
+                  publish(Debug(self.self.path.toString, _, s"now watched by $watcher"))
+                )
             } else asyncF.unit
           )
         } else if (!watcheeSelf && watcherSelf) {

--- a/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
+++ b/src/main/scala/com/suprnation/actor/engine/ActorCell.scala
@@ -195,7 +195,7 @@ object ActorCell {
               // If the system is suspended, we do not ping.
               .race(
                 (Temporal[F].sleep(1 second) >> dispatchContext.mailbox.deadLockCheck
-                  .ifM(sendSystemMessage(pingMessage), ().pure[F])).foreverM
+                  .ifM(sendSystemMessage(pingMessage), Async[F].unit)).foreverM
               )
               .void
           )


### PR DESCRIPTION
This small PR does the following 3 things:

1. Fixes the type of the argument in `SupervisorStrategy.escalateDefault` from `Any` to `Throwable` to match the `Decider` type. Unless we do this, using this decider yields the following error:
```java.lang.AbstractMethodError: Receiver class [...] does not define or inherit an implementation of the resolved method 'abstract boolean isDefinedAt(java.lang.Object)' of interface scala.PartialFunction.```

5. Fixes the actor creation examples in the README to use the context rather than the actor system for children actors, as discussed in #38.

6. Adjusts a few uses of `ifM` to use `whenA` instead, so as to avoid an unnecessary `pure`/`flatMap` combination.