### PR TITLE
Add microbenching test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@
 /qbin
 
 # sbt's target directories
-/target/
+*/target/*
 /project/**/target/
 /test/macro-annot/target/
 /test/files/target/

--- a/benchmark/src/main/scala/com/suprnation/actor/ActorBench.scala
+++ b/benchmark/src/main/scala/com/suprnation/actor/ActorBench.scala
@@ -29,9 +29,9 @@ class ActorBench extends ActorJmhSupport[ReplyingActorRef[IO, Input, Int]] {
   }
 
   @Benchmark
-  @Warmup(iterations = 1, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-  @Measurement(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
-  @Fork(0)
+//   @Warmup(iterations = 1, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+//   @Measurement(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+//   @Fork(0)
   def ask(): Unit = bench { (system, actor) =>
     for {
       _ <- actor ? Hi(1234)

--- a/benchmark/src/main/scala/com/suprnation/actor/ActorBench.scala
+++ b/benchmark/src/main/scala/com/suprnation/actor/ActorBench.scala
@@ -1,0 +1,40 @@
+package com.suprnation.actor
+
+import org.openjdk.jmh.annotations._
+import cats.effect.implicits.*
+import cats.implicits.*
+import cats.effect.IO
+import java.util.concurrent.TimeUnit
+import com.suprnation.actor.Actor.ReplyingReceive
+import com.suprnation.benchmark.ActorJmhSupport
+
+sealed trait Input
+case class Hi(response: Int) extends Input
+case class Error(error: String) extends Exception(error) with Input
+
+@State(Scope.Benchmark)
+class ActorBench extends ActorJmhSupport[ReplyingActorRef[IO, Input, Int]] {
+
+  lazy val askReceiver: ReplyingActor[IO, Input, Int] = new ReplyingActor[IO, Input, Int] {
+    override def receive: ReplyingReceive[IO, Any, Int] = {
+      case Hi(response)       => response.pure[IO]
+      case err @ Error(error) => IO.raiseError(err)
+    }
+  }
+
+  override def init: ActorSystem[IO] => IO[ReplyingActorRef[IO, Input, Int]] = { system =>
+    for {
+      actor <- system.replyingActorOf(askReceiver)
+    } yield actor
+  }
+
+  @Benchmark
+  @Warmup(iterations = 1, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+  @Fork(0)
+  def ask(): Unit = bench { (system, actor) =>
+    for {
+      _ <- actor ? Hi(1234)
+    } yield ()
+  }
+}

--- a/benchmark/src/main/scala/com/suprnation/benchmark/ActorJmhSupport.scala
+++ b/benchmark/src/main/scala/com/suprnation/benchmark/ActorJmhSupport.scala
@@ -1,0 +1,35 @@
+package com.suprnation.benchmark
+
+import cats.effect.unsafe.IORuntime
+
+import org.openjdk.jmh.annotations._
+import com.suprnation.actor.ActorSystem
+import cats.effect.IO
+import cats.effect.IO.consoleForIO
+
+trait ActorJmhSupport[Env] {
+
+  private var system: ActorSystem[IO] = _
+  private var release: IO[Unit] = _
+  private var env: Env | Null = _
+
+  def init: ActorSystem[IO] => IO[Env]
+
+  @Setup
+  def setup(): Unit = {
+    val (s, r) = ActorSystem("Benchmark").allocated.unsafeRunSync()(IORuntime.global)
+    system = s
+    release = r
+    env = init(system).unsafeRunSync()(IORuntime.global)
+  }
+
+  @TearDown
+  def teardown(): Unit = {
+    release.unsafeRunSync()(IORuntime.global)
+    system = null
+    env = null
+  }
+
+  def bench[A](f: (ActorSystem[IO], Env) => IO[A]): Unit =
+    f(system, env.nn).unsafeRunSync()(IORuntime.global)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,16 @@ ThisBuild / licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICE
 ThisBuild / crossScalaVersions := Seq("2.13.16", "3.3.4")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
+lazy val benchmark = project
+  .in(file("benchmark/"))
+  .dependsOn(root)
+  .enablePlugins(JmhPlugin)
+  .settings(
+    name := "cats-actors-benchmark",
+    scalaVersion := "3.3.4",
+    libraryDependencies ++= Seq()
+  )
+
 lazy val commonSettings = Seq(
   Test / parallelExecution := false,
   libraryDependencies ++= Seq(
@@ -52,7 +62,6 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     name := "cats-actors",
-
     Compile / unmanagedSourceDirectories ++= Seq(
       baseDirectory.value / "src" / "main" / "scala"
     ),
@@ -64,8 +73,8 @@ lazy val root = (project in file("."))
       val artPath = (Compile / packageBin / artifactPath).value
       val scalaVer = scalaBinaryVersion.value match {
         case "2.13" => "2_13"
-        case "3" => "3"
-        case other => other.replace('.', '_')
+        case "3"    => "3"
+        case other  => other.replace('.', '_')
       }
       file(s"${artPath.getParent}/cats-actors_${scalaVer}-${version.value}.jar")
     },
@@ -74,8 +83,8 @@ lazy val root = (project in file("."))
       val artPath = (Compile / packageSrc / artifactPath).value
       val scalaVer = scalaBinaryVersion.value match {
         case "2.13" => "2_13"
-        case "3" => "3"
-        case other => other.replace('.', '_')
+        case "3"    => "3"
+        case other  => other.replace('.', '_')
       }
       file(s"${artPath.getParent}/cats-actors_${scalaVer}-${version.value}-sources.jar")
     },
@@ -83,8 +92,8 @@ lazy val root = (project in file("."))
       val artPath = (Compile / packageDoc / artifactPath).value
       val scalaVer = scalaBinaryVersion.value match {
         case "2.13" => "2_13"
-        case "3" => "3"
-        case other => other.replace('.', '_')
+        case "3"    => "3"
+        case other  => other.replace('.', '_')
       }
       file(s"${artPath.getParent}/cats-actors_${scalaVer}-${version.value}-javadoc.jar")
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-github-dependency-submission" % "3.1.0")


### PR DESCRIPTION
Per the discussion we were having in issues - I thought about maybe doing something with testcontainers + rabbitmq to do a more realistic test, but did a survey of how some other libraries were doing it, and this seems like a pretty light weight and extensible approach. 

I figure I could PR this very basic test, then if we want to extend it or focus more specifically on testing the mailbox we could talk about what kinds of microbenchmarks that would be useful, and then if this lands on main, ill update the other PR and take a look at how changing the queue implementation impacts those benchmarks. 

Also:
```
[info] Result "com.suprnation.actor.ActorBench.ask":
[info]   18407.135 ±(99.9%) 1426.900 ops/s [Average]
[info]   (min, avg, max) = (13696.560, 18407.135, 21082.638), stdev = 1904.870
[info]   CI (99.9%): [16980.235, 19834.035] (assumes normal distribution)
```